### PR TITLE
Use class/const directly again rather than via var.

### DIFF
--- a/words/source/Dictionary.js
+++ b/words/source/Dictionary.js
@@ -11,7 +11,7 @@
 
 // A simple dictionary class to encapsulate the set of words that are
 // considered valid for game purposes.
-var Dictionary = class {
+class Dictionary {
   // Expects words to be provided as a return-delimited string.
   constructor(words) {
     // TODO(wkorman): Use a trie for better memory efficiency and ship a

--- a/words/source/MovePicker.js
+++ b/words/source/MovePicker.js
@@ -10,10 +10,13 @@
 'use strict';
 
 defineParticle(({ DomParticle, resolver }) => {
-  importScripts(resolver('MovePicker/Dictionary.js'));
-  importScripts(resolver('MovePicker/Scoring.js'));
-  importScripts(resolver('MovePicker/Tile.js'));
-  importScripts(resolver('MovePicker/TileBoard.js'));
+  function importLibrary(filename) {
+    importScripts(resolver(`MovePicker/${filename}`));
+  }
+  importLibrary('Dictionary.js');
+  importLibrary('Scoring.js');
+  importLibrary('Tile.js');
+  importLibrary('TileBoard.js');
 
   const host = `move-picker`;
 

--- a/words/source/Scoring.js
+++ b/words/source/Scoring.js
@@ -10,10 +10,10 @@
 'use strict';
 
 // Selected words must be at least this long for submission.
-var MINIMUM_WORD_LENGTH = 3;
+const MINIMUM_WORD_LENGTH = 3;
 
 // Base score points for each character.
-var CHAR_SCORE = {
+const CHAR_SCORE = {
   A: 1,
   B: 3,
   C: 3,
@@ -44,9 +44,9 @@ var CHAR_SCORE = {
 
 // Multiplier applied based on word length. Tuples as (length, multiplier).
 // So 3 character words have no multiplier, 4 is 2x, etc.
-var WORD_LENGTH_MULTIPLIERS = [[3, 1], [4, 2], [6, 3], [8, 4], [12, 5]];
+const WORD_LENGTH_MULTIPLIERS = [[3, 1], [4, 2], [6, 3], [8, 4], [12, 5]];
 
-var Scoring = class {
+class Scoring {
   static _wordLengthMultiplier(wordLength) {
     for (let i = 0; i < WORD_LENGTH_MULTIPLIERS.length; i++) {
       if (wordLength <= WORD_LENGTH_MULTIPLIERS[i][0])

--- a/words/source/Tile.js
+++ b/words/source/Tile.js
@@ -10,7 +10,7 @@
 'use strict';
 
 // A specific tile on the board with an index, position and character.
-var Tile = class {
+class Tile {
   constructor(charIndex, letter) {
     this._charIndex = charIndex;
     this._letter = letter;

--- a/words/source/TileBoard.js
+++ b/words/source/TileBoard.js
@@ -10,7 +10,7 @@
 'use strict';
 
 // Taken from Wikipedia at https://goo.gl/f4NJEq.
-var CHAR_FREQUENCIES = [
+const CHAR_FREQUENCIES = [
   ['A', 8.167],
   ['B', 1.492],
   ['C', 2.782],
@@ -39,11 +39,11 @@ var CHAR_FREQUENCIES = [
   ['Z', 0.074]
 ];
 
-var BOARD_HEIGHT = 7;
-var BOARD_WIDTH = 7;
-var TILE_COUNT = BOARD_WIDTH * BOARD_HEIGHT;
+const BOARD_HEIGHT = 7;
+const BOARD_WIDTH = 7;
+const TILE_COUNT = BOARD_WIDTH * BOARD_HEIGHT;
 
-var TileBoard = class {
+class TileBoard {
   constructor(board) {
     this._shuffleAvailableCount = board ? board.shuffleAvailableCount : 0;
     this._rows = [];


### PR DESCRIPTION
Something changed with particle loading and/or script importing and the duplicate identifier errors seem to be no more.