### PR TITLE
Persist move in view data to allow move selection post-suggestion-replan on ui events.

### DIFF
--- a/words/GamePane.manifest
+++ b/words/GamePane.manifest
@@ -12,8 +12,9 @@ import 'Stats.schema'
 
 import 'https://$cdn/artifacts/People/Person.schema'
 
-particle MovePicker in 'source/MovePicker.js'
-  MovePicker(in Person person, inout Board board, inout Move move, inout Stats stats)
+particle GamePane in 'source/GamePane.js'
+  GamePane(in Person person, inout Board board, inout Move move, inout Stats stats)
   affordance dom
   consume root
+#    provide leaderboard
   description `play Words`

--- a/words/LeaderboardPane.manifest
+++ b/words/LeaderboardPane.manifest
@@ -1,0 +1,16 @@
+# @license
+# Copyright (c) 2017 Google Inc. All rights reserved.
+# This code may only be used under the BSD style license found at
+# http://polymer.github.io/LICENSE.txt
+# Code distributed by Google as part of this project is also
+# subject to an additional IP rights grant found at
+# http://polymer.github.io/PATENTS.txt
+
+import 'Stats.schema'
+
+import 'https://$cdn/artifacts/People/Person.schema'
+
+particle LeaderboardPane in 'source/LeaderboardPane.js'
+  LeaderboardPane(in [Avatar] avatars, in Person person, in [Stats] stats)
+  consume leaderboard
+  description `see Words leaderboard`

--- a/words/TODO.txt
+++ b/words/TODO.txt
@@ -3,8 +3,12 @@
 1 add something like burning tiles to cause end-game
 1 show move word multiplier if > 1 in score info
 
+2 animate score points and multiplier alongside move when completed
 2 fix multi-tab bug that prevents word selection due to re-render and move reset
 2 use new Number type in schema for move
 2 support ending game and starting a new one
+  + board solver to identify word presence (could also allow "hints" button)
+  + board 'tick' post-turn to allow active tile types to mutate board
+  + refactor Board letters/tiles to allow tile types
 
 3 rework board to allow mouse-drag highlighting and animations

--- a/words/Words.recipes
+++ b/words/Words.recipes
@@ -5,15 +5,21 @@
 # subject to an additional IP rights grant found at
 # http://polymer.github.io/PATENTS.txt
 
-import 'MovePicker.manifest'
+import 'GamePane.manifest'
 
 recipe
   use #user as person
   create #board as board
   create #move as move
   create #stats as stats
-  MovePicker
+  # map #friends_avatar as avatars
+  GamePane
     move = move
     board = board
     stats = stats
     person <- person
+
+#  LeaderboardPane
+#    avatars <- avatars
+#    person <- person
+#    stats = stats

--- a/words/source/Dictionary.js
+++ b/words/source/Dictionary.js
@@ -29,4 +29,4 @@ class Dictionary {
   get size() {
     return this._dict.size;
   }
-};
+}

--- a/words/source/GamePane.js
+++ b/words/source/GamePane.js
@@ -11,7 +11,7 @@
 
 defineParticle(({ DomParticle, resolver }) => {
   function importLibrary(filename) {
-    importScripts(resolver(`MovePicker/${filename}`));
+    importScripts(resolver(`GamePane/${filename}`));
   }
   importLibrary('Dictionary.js');
   importLibrary('Scoring.js');
@@ -109,7 +109,7 @@ defineParticle(({ DomParticle, resolver }) => {
 
   const info = console.log.bind(
     console.log,
-    '%cMovePicker',
+    '%cGamePane',
     `background: #ff69b4; color: white; padding: 1px 6px 2px 7px; border-radius: 6px;`
   );
 
@@ -154,19 +154,19 @@ defineParticle(({ DomParticle, resolver }) => {
       if (state.dictionaryLoadingStarted) return;
 
       this._setState({ dictionaryLoadingStarted: true });
-      let particleRef = this;
-      let startstamp = performance.now();
+      const particleRef = this;
+      const startstamp = performance.now();
       fetch(DICTIONARY_URL).then(response =>
         response.text().then(text => {
-          let dictionaryState = new Dictionary(text);
-          let endstamp = performance.now();
-          let loadedMillis = Math.floor(endstamp - startstamp);
+          const dictionary = new Dictionary(text);
+          const endstamp = performance.now();
+          const elapsed = Math.floor(endstamp - startstamp);
           info(
-            `Loaded dictionary [time=${loadedMillis}ms, wordCount=${
-              dictionaryState.size
+            `Loaded dictionary [time=${elapsed}ms, wordCount=${
+              dictionary.size
             }].`
           );
-          particleRef._setState({ dictionary: dictionaryState });
+          particleRef._setState({ dictionary: dictionary });
         })
       );
     }

--- a/words/source/LeaderboardPane.js
+++ b/words/source/LeaderboardPane.js
@@ -1,0 +1,69 @@
+/**
+ * @license
+ * Copyright (c) 2017 Google Inc. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * Code distributed by Google as part of this project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+'use strict';
+
+defineParticle(({ DomParticle }) => {
+  const host = `show-leaderboard`;
+
+  const styles = `
+<style>
+  [${host}] {
+    display: flex;
+    flex-direction: column;
+    font-family: sans-serif;
+    font-size: 16px;
+    padding: 0 20px;
+    max-height: 400px;
+    overflow-x: hidden;
+    overflow-y: auto;
+  }
+  [${host}] [avatar] img {
+    height: 32px;
+    border-radius: 100%;
+    vertical-align: middle;
+    margin: 0 8px;
+  }
+  [${host}] [name] {
+    padding: 8px;
+    font-size: 0.7em;
+    min-height: 18px;
+  }
+  [${host}] [isme] [content] {
+    color: #f8f8f8;
+    background-color: #1873cd;
+  }
+</style>
+<div ${host}>
+  <template stat-entry>
+    <div stat isme$="{{isme}}">
+      <div name><span avatar><b>{{name}}</b><img src="{{src}}" title="{{name}}" alt="{{name}}"></span></div>
+      <div score>{{score}}</div>
+      <div move-count>{{moveCount}}</div>
+      <div longest-word>{{longestWord}}</div>
+      <div highest-scoring-word>{{highestScoringWord}}</div>
+      <!-- TODO(wkorman): timestamp -->
+    </div>
+  </template>
+  <div list>{{stats}}</div>
+</div>
+   `.trim();
+
+  return class extends DomParticle {
+    get template() {
+      return template;
+    }
+    _render(props) {
+      if (props.stats && props.person)
+        return {
+          // TODO
+        };
+    }
+  };
+});

--- a/words/source/Scoring.js
+++ b/words/source/Scoring.js
@@ -101,4 +101,7 @@ class Scoring {
     updatedValues['moveCount'] = stats.moveCount + 1;
     return updatedValues;
   }
+  static create() {
+    return { score: 0, moveCount: 0, startstamp: Date.now() };
+  }
 }

--- a/words/source/Tile.js
+++ b/words/source/Tile.js
@@ -37,4 +37,4 @@ class Tile {
       this.x
     }, y=${this.y}]`;
   }
-};
+}

--- a/words/source/TileBoard.js
+++ b/words/source/TileBoard.js
@@ -42,6 +42,7 @@ const CHAR_FREQUENCIES = [
 const BOARD_HEIGHT = 7;
 const BOARD_WIDTH = 7;
 const TILE_COUNT = BOARD_WIDTH * BOARD_HEIGHT;
+const DEFAULT_SHUFFLE_AVAILABLE_COUNT = 3;
 
 class TileBoard {
   constructor(board) {
@@ -178,6 +179,15 @@ class TileBoard {
   get toString() {
     return this._rows.map(r => r.map(c => c.letter).join('')).join('');
   }
+  static create() {
+    let boardChars = '';
+    for (let i = 0; i < TILE_COUNT; i++)
+      boardChars += TileBoard.pickCharWithFrequencies();
+    return {
+      letters: boardChars,
+      shuffleAvailableCount: DEFAULT_SHUFFLE_AVAILABLE_COUNT
+    };
+  }
   static pickCharWithFrequencies() {
     let pick = Math.random() * 100;
     let accumulator = 0;
@@ -193,7 +203,7 @@ class TileBoard {
   static indexToY(index) {
     return Math.floor(index / BOARD_HEIGHT);
   }
-};
+}
 
 TileBoard.info = console.log.bind(
   console.log,


### PR DESCRIPTION
https://github.com/PolymerLabs/arcs/commit/fe0d299575ca0392a52bf4f83bfd1cc7025f3e98 landed a month ago, and https://github.com/PolymerLabs/arcs-cdn/commit/f99943f9035f9a016256e32beaf8ce6c9a434c63 started rebuilding suggestions, which triggers a replan, on every ui event.

The game board adds a listener to mouse-over events, thus every such event began triggering a replan which produced an eventual call to `willReceiveProps` which would reset the move. This prevented a user from selecting multiple tiles or submitting a move. There is discussion around revising this to only rebuild suggestions when view data actually changes.

This patch persists the move in view data, which fixes the above issue though we still see continuous replans on mouse-over events. These produce a rapidly flickering Arc Explorer pane on the right of the app shell.

It also renames `MovePicker` to `GamePane` and adds the beginnings of a Leaderboard particle.
  