### PR TITLE
More styling and bug fixes.

### DIFF
--- a/social/Social/Particles.manifest
+++ b/social/Social/Particles.manifest
@@ -11,7 +11,7 @@ import 'https://$cdn/artifacts/People/Avatar.schema'
 import 'Post.manifest'
 
 particle ShowPosts in 'source/ShowPosts.js'
-  ShowPosts(in [Post] posts, in Person user, in [Person] people, in [Avatar] avatars)
+  ShowPosts(inout [Post] posts, in Person user, in [Person] people, in [Avatar] avatars)
   consume root
   description `show ${posts}`
 

--- a/social/Social/Social.recipes
+++ b/social/Social/Social.recipes
@@ -40,7 +40,7 @@ recipe
   use #identities as people
 
   OnlyShowPosts
-    posts = posts
+    posts <- posts
     user <- user
     avatars <- avatars
     people <- people

--- a/social/Social/assets/ic_rainbow_add.svg
+++ b/social/Social/assets/ic_rainbow_add.svg
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="24px" height="24px" viewBox="0 0 24 24" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 49 (51002) - http://www.bohemiancoding.com/sketch -->
+    <title>Artboard</title>
+    <desc>Created with Sketch.</desc>
+    <defs></defs>
+    <g id="Artboard" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="ic/gFAB/create">
+            <g id="gFAB">
+                <polygon id="Fill-2" fill="#4285F4" points="10 10 10 14.001 14.063 14.001 24 14.001 24 10"></polygon>
+                <polygon id="Fill-3" fill="#FBBC05" points="10 10 0 10 0 14.001 10 14.001 14.001 10"></polygon>
+                <rect id="Rectangle" fill="#34A853" x="10" y="14" width="4" height="10"></rect>
+                <polygon id="Fill-4" fill="#EA4335" points="10 0 10 14 14.001 10 14.001 0"></polygon>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/social/Social/source/ShowPosts.js
+++ b/social/Social/source/ShowPosts.js
@@ -31,16 +31,9 @@ defineParticle(({DomParticle, resolver, log}) => {
   }
   [${host}] [header] {
     background-color: white;
-    border-bottom: 1px solid grey;
-    border-top: 1px solid grey;
-    position: fixed;
+    border-bottom: 1px solid lightgrey;
+    border-top: 1px solid lightgrey;
     text-align: center;
-    top: 56px;
-    width: 512px;
-  }
-  [${host}] [postContent],
-  [${host}] [zerostate] {
-    margin-top: 162px;
   }
   [${host}] [header] [blogAvatar] {
     display: inline-block;
@@ -55,11 +48,11 @@ defineParticle(({DomParticle, resolver, log}) => {
   [${host}] [header] [blogDescription] {
     color: rgba(0, 0, 0, 0.4);
     margin-bottom: 14px;
+    text-decoration: underline lightgrey;
   }
   [${host}] [zerostate] {
     font-size: 32pt;
-    margin-left: 56px;
-    margin-right: 56px;
+    margin: 0.5em 56px auto 56px;
     text-align: center;
   }
   [${host}] [msg] input {
@@ -186,8 +179,8 @@ defineParticle(({DomParticle, resolver, log}) => {
       };
     }
     _render(props, {posts, avatars}) {
-      // TODO(wkorman): Use Arc-creator/owner name rather than viewing user
-      // for the blog author.
+      // TODO(wkorman): Use BlogMetadata for the creator name/avatar.
+      // For now we use the viewing user.
       const blogAuthor = props.user ? props.user.name : '';
       const blogAvatarUrl = props.user ? resolver(avatars[props.user.id]) : '';
       const blogAvatarStyle = `background: url('${
@@ -195,10 +188,8 @@ defineParticle(({DomParticle, resolver, log}) => {
       if (posts && posts.length > 0) {
         const sortedPosts = this._sortPostsByDateAscending(posts);
         const viewingUserName = props.user.name;
-        const viewingUserAvatar = '../../assets/avatars/user (13).png';
-        // const viewingUserAvatar = this._state.avatars[props.user.id].url;
-        // TODO(wkorman): Visibility seems like it's all or nothing. What was
-        // this originally intended to do?
+        const viewingUserAvatar =
+            props.user ? resolver(avatars[props.user.id]) : '';
         const visible = this._views.get('posts').canWrite;
         return {
           hideZeroState: true,

--- a/social/Social/source/WritePosts.js
+++ b/social/Social/source/WritePosts.js
@@ -10,7 +10,7 @@
 
 'use strict';
 
-defineParticle(({DomParticle, log}) => {
+defineParticle(({DomParticle, resolver, log}) => {
   const host = `social-write-posts`;
 
   const template = `
@@ -20,7 +20,7 @@ defineParticle(({DomParticle, log}) => {
   cursor: pointer;
   position: fixed;
   margin-left: 440px;
-  bottom: 80px;
+  bottom: 50px;
   padding: 8px;
   border-radius: 100%;
   box-shadow: 1px 1px 5px 0px rgba(0,0,0,0.75);
@@ -29,14 +29,16 @@ defineParticle(({DomParticle, log}) => {
 [${host}] i {
   display: block;
   border-radius: 100%;
-  font-size: 44px;
+  width: 24px;
+  height: 24px;
+  padding: 8px;
 }
 [${host}] i:active {
-  background-color: #b0e3ff;
+  background-color: #b0e3ff !important;
 }
 </style>
 <div ${host}>
-  <i class="material-icons" on-click="_onOpenEditor">add</i>
+  <i style="{{add_icon_style}}" on-click="_onOpenEditor"></i>
 </div>
   `.trim();
 
@@ -72,6 +74,9 @@ defineParticle(({DomParticle, log}) => {
       }
       return {
         name: state.name,
+        add_icon_style: `background: url(${
+            resolver(
+                'WritePosts/../assets/ic_rainbow_add.svg')}) center no-repeat;`
       };
     }
     _onOpenEditor(e, state) {


### PR DESCRIPTION
- Restore delete button on individual posts.
- Fix grey border coloring to match mocks.
- Apply rainbow 'add' icon asset.
- Revise add-post highlight to better match mocks.
- Underline add-a-description text.
- Stop using 'fixed' position for the blog header.

Part of https://github.com/PolymerLabs/arcs/issues/823